### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: poisutils
 Title: Poisson Consulting's Utility Functions
 Version: 0.0.0.9010
 Authors@R: c(
-    person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre")),
+    person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-7683-4592")),
     person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0000-0001-7388-1222"))
   )


### PR DESCRIPTION
Add Joe Thorley's ORCID (0000-0002-7683-4592).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)