### PR TITLE
Add fledge dev-version bump automation

### DIFF
--- a/.github/workflows/fledge-bump.yml
+++ b/.github/workflows/fledge-bump.yml
@@ -1,0 +1,19 @@
+# Daily fledge dev-version bump. Calls the reusable engine in poissonconsulting/.github.
+# Requires the org-level secrets FLEDGE_APP_ID and FLEDGE_APP_PRIVATE_KEY (passed via
+# `secrets: inherit`) and the companion fledge-tag-on-merge.yml workflow in this repo.
+
+name: fledge-bump
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fledge-bump:
+    uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@v1
+    secrets: inherit

--- a/.github/workflows/fledge-tag-on-merge.yml
+++ b/.github/workflows/fledge-tag-on-merge.yml
@@ -1,0 +1,18 @@
+# Tags the dev version on main after a release-path fledge-bump PR merges.
+# Required alongside fledge-bump.yml. Calls the reusable engine in poissonconsulting/.github.
+
+name: fledge-tag-on-merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'fledge-bump'
+    uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yml@v1
+    secrets: inherit


### PR DESCRIPTION
Adds the `fledge-bump` and `fledge-tag-on-merge` caller workflows (engine: poissonconsulting/.github@v1).

Requires the `poisson-fledge-bot` GitHub App and the `FLEDGE_APP_ID` / `FLEDGE_APP_PRIVATE_KEY` org secrets to be active. See poissonconsulting/.github/fledge-automation.md.